### PR TITLE
Upgrade boto3 version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   override:
-    - pip install tox tox-pyenv codeclimate-test-reporter
+    - pip install tox tox-pyenv coverage==4.3.4 codeclimate-test-reporter
     - pyenv global 2.7.11 3.1.5 3.2.6 3.3.6 3.4.4 3.5.1 pypy-4.0.1
 
 test:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     },
     install_requires=[
         'PyYAML==3.12',
-        'boto3==1.4.0',
+        'boto3==1.4.4',
         'requests==2.11.1',
         'colorama==0.3.7',
         'tqdm==4.8.4',


### PR DESCRIPTION
Upgrade boto3 version from 1.4.0 to 1.4.4.  When using fdep in the same environment as the s3contents package, the most recent boto3 version was being used, causing a version conflict.  This just updates fdep to use the most recent boto3 version (1.4.4).