### PR TITLE
REPORT-665 Handled PyYAML yaml.load(input) deprecation

### DIFF
--- a/fdep/config.py
+++ b/fdep/config.py
@@ -92,7 +92,7 @@ class FdepConfig(object):
 
         with open(path) as f:
             root_path = os.path.dirname(path)
-            return FdepConfig(root_path, yaml.load(f.read()))
+            return FdepConfig(root_path, yaml.full_load(f.read()))
 
     @classmethod
     def find_root_path(cls, current_path='.'):


### PR DESCRIPTION
PyYAML 5.1+ has [deprecated](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) `yaml.load(input)` without specifying the `Loader=...` parameter. 

This causes a warning in PyYAML 5.1+, and an **_error_** in PyYAML 6+:

```
  File "/usr/local/lib/python3.8/site-packages/fdep/__main__.py", line 32, in main
    config = FdepConfig.load(os.path.join(root_path, 'fdep.yml'))
  File "/usr/local/lib/python3.8/site-packages/fdep/config.py", line 95, in load
    return FdepConfig(root_path, yaml.load(f.read()))
TypeError: load() missing 1 required positional argument: 'Loader'
```

This MR updates the `yaml.load` call to explicitly specify a `Loader` parameter, using the `full_load` [shortcut "sugar" method](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation#how-to-disable-the-warning).